### PR TITLE
use default next browserlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,11 +83,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [
-    ">0.1%",
-    "not IE 11",
-    "not op_mini all",
-    "last 2 Edge versions"
-  ]
+  }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.15--canary.26.4755161044.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/canvas-example@1.0.15--canary.26.4755161044.0
  # or 
  yarn add @salutejs/canvas-example@1.0.15--canary.26.4755161044.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
